### PR TITLE
Use exit code 0 for non-errored exits (e.g. --skip_hmm, --skip_gsmm)

### DIFF
--- a/kemet.py
+++ b/kemet.py
@@ -2482,7 +2482,7 @@ if ktest in sorted(os.listdir()):
 if args.skip_hmm:
     if not args.quiet:
         print(manuscript_info)
-    sys.exit(1)
+    sys.exit(0)
 
 #### HMM - VERBOSITY SETTINGS
 if args.verbose:
@@ -2573,7 +2573,7 @@ with open(instruction_file) as f:
             if args.skip_gsmm:
                 if not args.quiet:
                     print(manuscript_info)
-                sys.exit(1)
+                sys.exit(0)
             else:
                 if args.hmm_mode == "kos" and args.gsmm_mode == "existing":
                     print('''


### PR DESCRIPTION
KEMET currently exits with code 1 when the `--skip_hmm` or `--skip_gsmm` options are enabled, even if no errors are encountered.

Since workflow tools such as Snakemake run commands in "strict" mode, any script that has a non-zero exit status indicates a "failure" in the workflow and halts execution of any other steps.

This PR simply changes the exit codes KEMET emits when skipping the HMM / GSMM steps to be 0, so that workflows using KEMET without those features can proceed.

Happy to hear feedback or answer any questions you may have as well!